### PR TITLE
Add option to parse imports only and an option to pass file contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ go get -u github.com/lukehoban/go-outline
 [{"label":"proc","type":"package",<...>}]
 ```
 
+To parse and return only imports
+```bash
+> go-outline -f file.go -imports-only
+```
+
 ### Schema
 ```go
 type Declaration struct {

--- a/main.go
+++ b/main.go
@@ -22,13 +22,19 @@ type Declaration struct {
 }
 
 var (
-	file = flag.String("f", "", "the path to the file to outline")
+	file        = flag.String("f", "", "the path to the file to outline")
+	importsOnly = flag.Bool("imports-only", false, "parse imports only")
 )
 
 func main() {
 	flag.Parse()
 	fset := token.NewFileSet()
-	fileAst, err := parser.ParseFile(fset, *file, nil, parser.ParseComments)
+	parserMode := parser.ParseComments
+	if *importsOnly == true {
+		parserMode = parser.ImportsOnly
+	}
+
+	fileAst, err := parser.ParseFile(fset, *file, nil, parserMode)
 	if err != nil {
 		reportError(fmt.Errorf("Could not parse file %s", *file))
 	}

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ type Declaration struct {
 var (
 	file        = flag.String("f", "", "the path to the file to outline")
 	importsOnly = flag.Bool("imports-only", false, "parse imports only")
+	src         = flag.String("src", "", "source code of the file to outline")
 )
 
 func main() {
@@ -34,7 +35,15 @@ func main() {
 		parserMode = parser.ImportsOnly
 	}
 
-	fileAst, err := parser.ParseFile(fset, *file, nil, parserMode)
+	var fileAst *ast.File
+	var err error
+
+	if len(*src) > 0 {
+		fileAst, err = parser.ParseFile(fset, *file, *src, parserMode)
+	} else {
+		fileAst, err = parser.ParseFile(fset, *file, nil, parserMode)
+	}
+
 	if err != nil {
 		reportError(fmt.Errorf("Could not parse file %s", *file))
 	}


### PR DESCRIPTION
- Autocomplete feature in VS Code Go extension uses `go-outline` to get imported packages. Having a "imports-only" option will help in skipping the overhead of parsing the complete file
- Autocomplete feature in VS Code Go extension also needs to run when the file has changes that is not saved. Therefore, an option to pass the file contents to `go-outline` would help too
