### PR TITLE
Fixing SIGSEGV when no file is parsed

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func main() {
 
 	if err != nil {
 		reportError(fmt.Errorf("Could not parse file %s", *file))
+		os.Exit(1)
 	}
 
 	declarations := []Declaration{}


### PR DESCRIPTION
If I run go-outline without any option, it falls into a segmentation fault [here](https://github.com/lukehoban/go-outline/blob/8309e4426dd05528daca4f34741e5de018810c50/main.go#L53).
```
$ go-outline
error: Could not parse file 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x4f04a3]
...
```
The fix is to os.Exit() after file parsing error is reported.